### PR TITLE
Add "delete draft schedule" button

### DIFF
--- a/src/services/backend/schedules.ts
+++ b/src/services/backend/schedules.ts
@@ -73,6 +73,15 @@ export const schedulesApi = baseApi.injectEndpoints({
         { type: 'Schedules', id: month },
       ],
     }),
+    deleteSchedule: builder.mutation<void, Backend.Schedule>({
+      query: (schedule) => ({
+        url: `schedules/${dayjs(schedule.month).format('YYYY-MM-DD')}`,
+        method: 'DELETE',
+      }),
+      invalidatesTags: (result, error, { month }) => [
+        { type: 'Schedules', id: month },
+      ],
+    }),
   }),
 });
 
@@ -81,5 +90,6 @@ export const {
   useGetScheduleForMonthQuery,
   useGetMonthsToPlanQuery,
   useAddScheduleMutation,
+  useDeleteScheduleMutation,
   useUpdateScheduleMutation,
 } = schedulesApi;

--- a/src/utils/helpers/api-builder.tsx
+++ b/src/utils/helpers/api-builder.tsx
@@ -1,14 +1,16 @@
 import { CircularProgress } from '@mui/material';
-import { useEffect, useMemo } from 'react';
+import { ReactElement, useEffect, useMemo } from 'react';
+
+type NotUndefined<T> = T extends undefined ? never : T;
 
 type SuccessArgs<Q extends QueryResults> = {
-  [K in keyof Q]: NonNullable<Q[K]['data']>;
+  [K in keyof Q]: NotUndefined<Q[K]['data']>;
 };
 type ErrorArgs<Q extends QueryResults> = {
   reasons: (keyof Q)[];
 };
 
-type ApiStateBuilder = () => JSX.Element;
+type ApiStateBuilder = () => ReactElement;
 type SuccessBuilder<Q extends QueryResults> = (
   args: SuccessArgs<Q>
 ) => ReturnType<ApiStateBuilder>;

--- a/src/views/Planner/PlannerHomePage/PlannerHomePage.tsx
+++ b/src/views/Planner/PlannerHomePage/PlannerHomePage.tsx
@@ -23,6 +23,10 @@ function ThisMonthActions() {
       }),
     },
     onSuccess: ({ schedule }) => {
+      if (schedule === null) {
+        return <></>;
+      }
+
       if (schedule.isPublished) {
         return (
           <div>

--- a/src/views/Planner/PlannerSchedulePage/PlannerPublishedSchedulePage.tsx
+++ b/src/views/Planner/PlannerSchedulePage/PlannerPublishedSchedulePage.tsx
@@ -32,7 +32,7 @@ function PlannerPublishedSchedulePageWithAPI() {
       }),
     },
     onLoad: ({ schedule }) => {
-      if (!schedule.isPublished) {
+      if (schedule !== null && !schedule.isPublished) {
         navigate(`/planner/schedules/${month}/edit`);
       }
     },


### PR DESCRIPTION
## User flow
1. Click "Delete"
![image](https://user-images.githubusercontent.com/8487294/175484138-cec40b74-64f1-4e13-ace1-831a0e5b3b0d.png)
2. Confirmation dialog appears
![image](https://user-images.githubusercontent.com/8487294/175484146-100b03f2-488b-45ac-979c-7c185d320730.png)
3. Planner is redirected to drafts page

## Other fixes
And also fixes the PlannerHomePage from throwing an error when there isn't a currently published plan.