### PR TITLE
Optimise member update calls

### DIFF
--- a/src/views/Planner/PlannerMembersPage/PlannerMembersPage.tsx
+++ b/src/views/Planner/PlannerMembersPage/PlannerMembersPage.tsx
@@ -94,10 +94,23 @@ function PlannerMembersPageWithAPI() {
               });
             } else {
               // Member already exists
+              const mappedMember = mappedMembers.find(
+                (m) => m.callsign === member.callsign
+              )!;
+
+              // Check if member needs an update
+              const needsUpdate = Object.keys(member.roles).some((role) => {
+                return member.roles[role] !== mappedMember.roles[role];
+              });
+
+              if (!needsUpdate) {
+                continue;
+              }
+
+              // Update member
+              const memberId = mappedMember.id;
               await updateMemberRoles({
-                memberId: mappedMembers.find(
-                  (m) => m.callsign === member.callsign
-                )!.id,
+                memberId: memberId,
                 roleNames: roleNames,
               });
             }


### PR DESCRIPTION
Previously, saving any changes on the members page will call the API once for every member, regardless of whether or not that member requires an update. This causes the saving to be quite slow.

With this update, an API call will only be sent when a member _needs_ an update. 