### PR TITLE
AEGIS-134 Add support for multi-date requests, optimistic request editing

### DIFF
--- a/src/components/general/multi-date-picker/index.tsx
+++ b/src/components/general/multi-date-picker/index.tsx
@@ -45,8 +45,8 @@ export type MultiDatePickerProps = {
   label: string;
   onSelectionChanged: (selectedDates: Dayjs[]) => void;
   selection: Dayjs[];
-  minDate: Dayjs;
-  maxDate: Dayjs;
+  minDate?: Dayjs;
+  maxDate?: Dayjs;
   textFieldProps?: Partial<TextFieldProps>;
 };
 
@@ -116,22 +116,29 @@ function MultiDatePicker(
     setAnchorEl(null);
   }
 
-  const allDatesInMonth = useMemo(
-    () =>
-      [...iterateDates(minDate.toDate(), maxDate.toDate())].map((date) =>
+  const allDatesInMonth = useMemo(() => {
+    if (minDate !== undefined && maxDate !== undefined) {
+      return [...iterateDates(minDate.toDate(), maxDate.toDate())].map((date) =>
         dayjs(date)
-      ),
-    [minDate, maxDate]
-  );
+      );
+    } else {
+      return undefined;
+    }
+  }, [minDate, maxDate]);
+
+  const isSelectionEmpty = selection.length === 0;
 
   return (
     <>
       <TextField
-        aria-describedby="text-field"
         label={label}
         value=""
         error={false}
-        inputProps={{ value: displayString }}
+        inputProps={{
+          value: !isSelectionEmpty ? displayString : '',
+          placeholder: isSelectionEmpty ? displayString : '',
+        }}
+        InputLabelProps={{ shrink: true }}
         InputProps={{
           endAdornment: (
             <InputAdornment position="end">
@@ -171,30 +178,23 @@ function MultiDatePicker(
           onChange={onChange}
           value={null}
           closeOnSelect={false}
-          renderInput={({ value, ...params }) => (
-            <TextField
-              {...params}
-              label={label}
-              value=""
-              error={false}
-              inputProps={{ value: displayString }}
-              {...textFieldProps}
-            />
-          )}
+          renderInput={({ value, ...params }) => <></>}
           renderDay={renderPickerDay}
         />
         <Box display="flex" flexDirection="column" alignItems="end">
           <Box display="flex" gap={1} padding={2}>
-            <Button
-              variant="outlined"
-              startIcon={<SelectAllOutlined />}
-              size="small"
-              onClick={() => {
-                onSelectionChanged(allDatesInMonth);
-              }}
-            >
-              Select all
-            </Button>
+            {allDatesInMonth !== undefined && (
+              <Button
+                variant="outlined"
+                startIcon={<SelectAllOutlined />}
+                size="small"
+                onClick={() => {
+                  onSelectionChanged(allDatesInMonth);
+                }}
+              >
+                Select all
+              </Button>
+            )}
             <Button
               variant="outlined"
               startIcon={<Clear />}

--- a/src/components/requests/form/CreateRequestButton.tsx
+++ b/src/components/requests/form/CreateRequestButton.tsx
@@ -18,15 +18,12 @@ function CreateRequestButton() {
     onSuccess: ({ members }) => {
       const onRequestCreate = async (requestPeriods: RequestPeriod[]) => {
         await addRequests(
-          requestPeriods.map(
-            ({ startDate, endDate, reason, member, type }) => ({
-              startDate: startDate.format('YYYY-MM-DD'),
-              endDate: endDate.format('YYYY-MM-DD'),
-              reason,
-              type,
-              memberId: member.id,
-            })
-          )
+          requestPeriods.map(({ dates, reason, member, type }) => ({
+            dates: dates.map((date) => date.format('YYYY-MM-DD')),
+            reason,
+            type,
+            memberId: member.id,
+          }))
         );
         setCreating(false);
       };

--- a/src/components/requests/form/RequestForm.tsx
+++ b/src/components/requests/form/RequestForm.tsx
@@ -14,15 +14,13 @@ function RequestForm(props: RequestFormProps) {
   const form = useRef<HTMLFormElement>();
   const [periods, setPeriods] = useState<PartialRequestPeriod[]>([
     {
-      startDate: null,
-      endDate: null,
+      dates: [],
       member: null,
       reason: '',
       type: null,
     },
     {
-      startDate: null,
-      endDate: null,
+      dates: [],
       member: null,
       reason: '',
       type: null,
@@ -39,8 +37,7 @@ function RequestForm(props: RequestFormProps) {
       setPeriods([
         ...periods,
         {
-          startDate: null,
-          endDate: null,
+          dates: [],
           member: null,
           reason: '',
           type: null,

--- a/src/components/requests/form/RequestFormItem.tsx
+++ b/src/components/requests/form/RequestFormItem.tsx
@@ -1,3 +1,4 @@
+import MultiDatePicker from '@components/general/multi-date-picker';
 import {
   Add,
   DateRangeOutlined,
@@ -21,15 +22,12 @@ import {
   InputLabel,
   Divider,
 } from '@mui/material';
-import { DatePicker } from '@mui/x-date-pickers';
 import { Backend } from '@typing/backend';
-import { ERROR_END_DATE_BEFORE_START_DATE } from '@utils/constants/string';
 import { getCardColor } from '@utils/theme';
 import { Dayjs } from 'dayjs';
 
 export type PartialRequestPeriod = {
-  startDate: Dayjs | null;
-  endDate: Dayjs | null;
+  dates: Dayjs[];
   member: Backend.Entry<Backend.Member> | null;
   reason: string;
   type: Backend.RequestType | null;
@@ -103,64 +101,27 @@ function RequestFormItem(props: RequestFormItemProps) {
           </Box>
           <Divider />
           <Grid container spacing={1}>
-            <Grid item xs={12} sm={6}>
-              <DatePicker
-                label="Start date"
+            <Grid item xs={12}>
+              <MultiDatePicker
+                label="Date/s"
                 inputFormat="DD/MM/YYYY"
                 onOpen={() => {
                   onInputFocus();
                 }}
-                onChange={(date) => {
-                  request.startDate = date;
-                  if (request.endDate === null) {
-                    request.endDate = date;
-                  }
+                onSelectionChanged={(dates) => {
+                  request.dates = dates;
                   onUpdate();
                 }}
-                value={request.startDate}
-                renderInput={(params) => (
-                  <TextField
-                    {...params}
-                    onFocus={() => {
-                      onInputFocus();
-                    }}
-                    variant="filled"
-                    required={!isPromptItem}
-                    fullWidth
-                    autoComplete="off"
-                  />
-                )}
-              />
-            </Grid>
-            <Grid item xs={12} sm={6}>
-              <DatePicker
-                label="End date"
-                inputFormat="DD/MM/YYYY"
-                onOpen={() => {
-                  onInputFocus();
+                textFieldProps={{
+                  variant: 'filled',
+                  fullWidth: true,
+                  required: !isPromptItem,
+                  autoComplete: 'off',
+                  onFocus: () => {
+                    onInputFocus();
+                  },
                 }}
-                onChange={(date) => {
-                  request.endDate = date;
-                  onUpdate();
-                }}
-                value={request.endDate}
-                renderInput={(params) => {
-                  const hasError = request.endDate?.isBefore(request.startDate);
-                  return (
-                    <TextField
-                      {...params}
-                      onFocus={() => {
-                        onInputFocus();
-                      }}
-                      error={hasError}
-                      helperText={hasError && ERROR_END_DATE_BEFORE_START_DATE}
-                      variant="filled"
-                      required={!isPromptItem}
-                      fullWidth
-                      autoComplete="off"
-                    />
-                  );
-                }}
+                selection={request.dates}
               />
             </Grid>
             <Grid item xs={12} sm={6}>

--- a/src/services/backend/requests.ts
+++ b/src/services/backend/requests.ts
@@ -47,6 +47,24 @@ export const requestsApi = baseApi.injectEndpoints({
         body: requestIds,
       }),
       invalidatesTags: [{ type: 'Requests', id: 'LIST' }],
+      onQueryStarted(requestIds, { dispatch, queryFulfilled }) {
+        const patchResult = dispatch(
+          requestsApi.util.updateQueryData(
+            'getRequests',
+            undefined,
+            (requests: RequestResponse[]) => {
+              // Mutate list
+              requestIds.forEach((id) => {
+                const index = requests.findIndex((r) => r.id === id);
+                if (index !== -1) {
+                  requests.splice(index, 1);
+                }
+              });
+            }
+          )
+        );
+        queryFulfilled.catch(patchResult.undo);
+      },
     }),
     updateRequest: builder.mutation<void, Backend.WithId<Backend.Request>>({
       query: (request) => ({

--- a/src/services/backend/requests.ts
+++ b/src/services/backend/requests.ts
@@ -55,6 +55,26 @@ export const requestsApi = baseApi.injectEndpoints({
         body: request,
       }),
       invalidatesTags: [{ type: 'Requests', id: 'LIST' }],
+      onQueryStarted({ id, ...request }, { dispatch, queryFulfilled }) {
+        const patchResult = dispatch(
+          requestsApi.util.updateQueryData(
+            'getRequests',
+            undefined,
+            (requests: RequestResponse[]) => {
+              // Mutate list
+              const index = requests.findIndex((r) => r.id === id);
+
+              if (index !== -1) {
+                requests[index] = {
+                  ...requests[index],
+                  ...request,
+                };
+              }
+            }
+          )
+        );
+        queryFulfilled.catch(patchResult.undo);
+      },
     }),
   }),
 });

--- a/src/typing/backend.ts
+++ b/src/typing/backend.ts
@@ -58,26 +58,27 @@ export namespace Backend {
   export type RequestType = 'Work' | 'Personal';
 
   export type Request = {
-    startDate: string;
-    endDate: string;
-    reason: string;
     memberId: number;
     type: RequestType;
+    reason: string;
+    dates: string[];
   };
 
-  export type Entry<T> = {
-    id: number;
-    createdAt: string;
-    updatedAt: string;
-  } & {
-    // If any attribute is an array, it is a list of entries.
-    // If it is an object, it is a single entry.
-    [K in keyof T]: T[K] extends Array<infer U>
-      ? Entry<U>[]
-      : T[K] extends object
-      ? Entry<T[K]>
-      : T[K];
-  };
+  export type Entry<T> = T extends object
+    ? {
+        id: number;
+        createdAt: string;
+        updatedAt: string;
+      } & {
+        // If any attribute is an array, it is a list of entries.
+        // If it is an object, it is a single entry.
+        [K in keyof T]: T[K] extends Array<infer U>
+          ? Entry<U>[]
+          : T[K] extends object
+          ? Entry<T[K]>
+          : T[K];
+      }
+    : T;
 
   export type WithId<T> = {
     id: number;

--- a/src/typing/index.ts
+++ b/src/typing/index.ts
@@ -12,10 +12,10 @@ export type AvailableQualifiedMember = BaseQualifiedMember & {
 };
 
 type Reason = {
-	text: string;
-	dateSubmitted: string | null;
-	isLate: boolean;
-	type: Backend.RequestType | null;
+  text: string;
+  dateSubmitted: string | null;
+  isLate: boolean;
+  type: Backend.RequestType | null;
 };
 
 export type UnavailableQualifiedMember = BaseQualifiedMember & {
@@ -39,8 +39,7 @@ export type Schedule = {
 };
 
 export type RequestPeriod = {
-  startDate: Dayjs;
-  endDate: Dayjs;
+  dates: Dayjs[];
   member: Backend.Entry<Backend.Member>;
   reason: string;
   type: Backend.RequestType;

--- a/src/utils/helpers/schedule.ts
+++ b/src/utils/helpers/schedule.ts
@@ -56,9 +56,9 @@ export const getScheduleItemsByDay = (
     Record<number, ScheduleItemPropsWithoutCallback>
   > = {};
 
-	const cutOffDate = new Date(startDate);
-	cutOffDate.setMonth(startDate.getMonth() - 1);
-	cutOffDate.setDate(25);
+  const cutOffDate = new Date(startDate);
+  cutOffDate.setMonth(startDate.getMonth() - 1);
+  cutOffDate.setDate(25);
 
   const dutyCounts: Map<number, number> = new Map();
   for (const duty of duties) {
@@ -99,11 +99,11 @@ export const getScheduleItemsByDay = (
           })
           .map((member) => {
             const memberRequests = member.requests.filter((request) => {
-              return !(
-                dayjs(request.endDate).isBefore(duty.date, 'day') ||
-                dayjs(request.startDate).isAfter(duty.date, 'day')
+              return request.dates.some((date) =>
+                dayjs(date).isSame(duty.date, 'day')
               );
             });
+
             if (memberRequests.length === 0) {
               return {
                 ...member,
@@ -115,18 +115,16 @@ export const getScheduleItemsByDay = (
               return {
                 ...member,
                 isAvailable: false,
-                unavailableReasons: memberRequests.map(
-                  (request) => {
-										const createdAtDate = dayjs(request.createdAt);
-										const isLate = createdAtDate.isAfter(cutOffDate);
-										return({
-											text: `Request: ${request.reason}`,
-											dateSubmitted: request.createdAt, 
-											isLate,
-											type: request.type
-										})
-									}
-                ),
+                unavailableReasons: memberRequests.map((request) => {
+                  const createdAtDate = dayjs(request.createdAt);
+                  const isLate = createdAtDate.isAfter(cutOffDate);
+                  return {
+                    text: `Request: ${request.reason}`,
+                    dateSubmitted: request.createdAt,
+                    isLate,
+                    type: request.type,
+                  };
+                }),
                 dutyCount: dutyCounts.get(member.id) || 0,
               };
             }
@@ -210,7 +208,12 @@ export const getScheduleItemsByDay = (
                 isAvailable: false,
                 unavailableReasons: [
                   ...oldUnavailableReasons,
-                  {text: 'Scheduled on same day', dateSubmitted: null, isLate: false, type: null},
+                  {
+                    text: 'Scheduled on same day',
+                    dateSubmitted: null,
+                    isLate: false,
+                    type: null,
+                  },
                 ],
               };
             }
@@ -224,7 +227,12 @@ export const getScheduleItemsByDay = (
                 isAvailable: false,
                 unavailableReasons: [
                   ...oldUnavailableReasons,
-                  {text: 'Scheduled on previous day', dateSubmitted: null, isLate: false, type: null},
+                  {
+                    text: 'Scheduled on previous day',
+                    dateSubmitted: null,
+                    isLate: false,
+                    type: null,
+                  },
                 ],
               };
             }
@@ -302,11 +310,11 @@ export function scheduleToScheduleTableProps(
   };
 }
 
-export function requestTypeToEmoji(requestType: Backend.RequestType){
-	switch (requestType){
-		case "Work":
-			return "💼"
-		case "Personal":
-			return "👪"
-	}
+export function requestTypeToEmoji(requestType: Backend.RequestType) {
+  switch (requestType) {
+    case 'Work':
+      return '💼';
+    case 'Personal':
+      return '👪';
+  }
 }

--- a/src/utils/mock-data/backend.ts
+++ b/src/utils/mock-data/backend.ts
@@ -404,7 +404,7 @@ export const QUALIFICATIONS: MockQualification[] = [
   {
     memberId: 38,
     roles: ['A2'],
-  }
+  },
 ];
 
 export const SCHEDULES: Backend.Schedule[] = [
@@ -428,15 +428,17 @@ export const SCHEDULES: Backend.Schedule[] = [
 export const REQUESTS: Backend.Request[] = [
   {
     memberId: 15,
-    startDate: '2022-07-25',
-    endDate: '2022-08-05',
+    dates: [
+      ...iterateDates(new Date('2022-07-25'), new Date('2022-08-05')),
+    ].map((date) => dayjs(date).format('YYYY-MM-DD')),
     reason: 'Cse: Para Counselling',
     type: 'Work',
   },
   {
     memberId: 4,
-    startDate: '2022-07-01',
-    endDate: '2022-07-12',
+    dates: [
+      ...iterateDates(new Date('2022-07-01'), new Date('2022-07-12')),
+    ].map((date) => dayjs(date).format('YYYY-MM-DD')),
     reason: 'Overseas: ',
     type: 'Personal',
   },

--- a/src/views/Member/MemberNewRequestForm/MemberNewRequestForm.tsx
+++ b/src/views/Member/MemberNewRequestForm/MemberNewRequestForm.tsx
@@ -22,15 +22,12 @@ function MemberNewRequestFormWithAPI() {
         members: members,
         onRequestCreate: async (requestPeriods: RequestPeriod[]) => {
           await addRequests(
-            requestPeriods.map(
-              ({ startDate, endDate, reason, member, type }) => ({
-                startDate: startDate.format('YYYY-MM-DD'),
-                endDate: endDate.format('YYYY-MM-DD'),
-                reason,
-                type,
-                memberId: member.id,
-              })
-            )
+            requestPeriods.map(({ dates, reason, member, type }) => ({
+              dates: dates.map((date) => date.format('YYYY-MM-DD')),
+              reason,
+              type,
+              memberId: member.id,
+            }))
           );
           navigate('/requests');
         },

--- a/src/views/Member/MemberRequestsPage/MemberRequestsPage.tsx
+++ b/src/views/Member/MemberRequestsPage/MemberRequestsPage.tsx
@@ -40,8 +40,7 @@ function MemberRequestsPageWithAPI() {
           ...period,
           id: period.id,
           memberId: period.member.id,
-          startDate: dayjs(period.startDate),
-          endDate: dayjs(period.endDate),
+          dates: period.dates.map(dayjs),
           callsign: period.member.callsign,
         })),
         members,
@@ -85,10 +84,16 @@ function MemberRequestsPage(props: MemberRequestsPageProps) {
                 );
 
                 if (oldRequest) {
+                  const requestDates = request.dates.map((date) => dayjs(date));
+                  const hasDatesChanged =
+                    requestDates.length !== oldRequest.dates.length ||
+                    requestDates.some(
+                      (date, index) =>
+                        !date.isSame(oldRequest.dates[index], 'day')
+                    );
                   if (
                     oldRequest.callsign !== request.callsign ||
-                    oldRequest.startDate.isSame(request.startDate, 'day') ||
-                    oldRequest.endDate.isSame(request.endDate, 'day') ||
+                    hasDatesChanged ||
                     oldRequest.reason !== request.reason ||
                     oldRequest.type !== request.type
                   ) {
@@ -97,17 +102,17 @@ function MemberRequestsPage(props: MemberRequestsPageProps) {
                     )!.id;
                     await updateRequest({
                       ...request,
-                      startDate: dayjs(request.startDate).format('YYYY-MM-DD'),
-                      endDate: dayjs(request.endDate).format('YYYY-MM-DD'),
+                      dates: requestDates.map((date) =>
+                        date.format('YYYY-MM-DD')
+                      ),
                       memberId: newMemberId,
                     });
                   }
                 }
               }
             }}
-            requests={periods.map(({ startDate, endDate, ...rest }) => ({
-              startDate: startDate.toDate(),
-              endDate: endDate.toDate(),
+            requests={periods.map(({ dates, ...rest }) => ({
+              dates: dates.map((date) => date.toDate()),
               ...rest,
             }))}
           />


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/8487294/178242187-76fd5348-e373-4383-a6f3-cc87c974925a.png)
Multiple dates can be added to requests. Relevant queries and calculations have been updated to support this.

Editing requests are also now optimistic: the request table will assume that request editing is successful, before confirmation from the server. This means the request table will no longer have a moment of jitter where it reverts back to old data while waiting for an update from the server.

Related to https://github.com/RAiDSES/AEGIS-Backend/pull/19